### PR TITLE
Cambio de tipo de propiedad `Number` a `string`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+.env 
+# Ignore environment file
 # User-specific files
 *.rsuser
 *.suo

--- a/SorteosAPI/Models/AssignedNumber.cs
+++ b/SorteosAPI/Models/AssignedNumber.cs
@@ -13,7 +13,7 @@ namespace SorteosAPI.Models
         [Required(ErrorMessage = "El usuario es obligatorio.")]
         public int IdUser { get; set; }
 
-        public int Number { get; set; }
+        public string Number { get; set; }
         public bool IsActive { get; set; } = true;
     }
 
@@ -26,7 +26,7 @@ namespace SorteosAPI.Models
         public string RaffleName { get; set; }
         public int IdUser { get; set; }
         public string UserName { get; set; }
-        public int Number { get; set; }
+        public string Number { get; set; }
         public bool IsActive { get; set; } = true;
     }
 }

--- a/SorteosAPI/Services/AssignedNumberService.cs
+++ b/SorteosAPI/Services/AssignedNumberService.cs
@@ -56,18 +56,18 @@ namespace SorteosAPI.Services
                         // Recuperar valores de salida
                         int? generatedNumber = generatedNumberParam.Value != DBNull.Value ? (int?)generatedNumberParam.Value : null;
                         bool success = successParam.Value != DBNull.Value && (bool)successParam.Value;
-                        string message = messageParam.Value != DBNull.Value ? messageParam.Value.ToString() : string.Empty;
+                        string message = messageParam.Value != DBNull.Value ? messageParam.Value?.ToString() ?? string.Empty : string.Empty;
 
                         // Asignar el número generado al modelo
-                        model.Number = generatedNumber ?? 0;
+                        model.Number = generatedNumber?.ToString() ?? "0";
 
-                        return (success, model, message);
+                        return (success, model, message ?? string.Empty);
                     }
                 }
             }
             catch (Exception ex)
             {
-                return (false, null, $"Ocurrió un error: {ex.Message}");
+                return (false, new AssignedNumberRaffer { Number = "0" }, $"Ocurrió un error: {ex.Message}");
             }
         }
     }

--- a/SorteosAPI/Services/ListNumberService.cs
+++ b/SorteosAPI/Services/ListNumberService.cs
@@ -58,7 +58,7 @@ namespace SorteosAPI.Services
                                     RaffleName = reader.GetString(reader.GetOrdinal("RaffleName")),
                                     IdUser = reader.GetInt32(reader.GetOrdinal("IdUser")),
                                     UserName = reader.GetString(reader.GetOrdinal("UserName")),
-                                    Number = reader.GetInt32(reader.GetOrdinal("Number")),
+                                    Number = reader.GetString(reader.GetOrdinal("Number")),
                                     IsActive = reader.GetBoolean(reader.GetOrdinal("IsActive"))
                                 });
                             }
@@ -73,7 +73,7 @@ namespace SorteosAPI.Services
             }
             catch (Exception ex)
             {
-                return (false, null, 0, $"Ocurrió un error: {ex.Message}");
+                return (false, new List<ListNumberRaffer>(), 0, $"Ocurrió un error: {ex.Message}");
             }
         }
     }


### PR DESCRIPTION
Se ha cambiado el tipo de la propiedad `Number` de `int` a `string` en las clases `AssignedNumber` y `ListNumberRaffer`. Esto afecta la asignación y recuperación de valores en los servicios correspondientes, asegurando que se manejen como cadenas. Además, se han realizado ajustes en el manejo de errores para evitar valores nulos y proporcionar valores predeterminados adecuados.